### PR TITLE
posix_spawnp is unavailable on watchOS and tvOS

### DIFF
--- a/Sources/POSIX/Spawn.swift
+++ b/Sources/POSIX/Spawn.swift
@@ -17,11 +17,13 @@ extension SpawnError : CustomStringConvertible {
     }
 }
 
+#if !os(watchOS) && !os(tvOS)
 public func spawn(arguments: [String]) throws -> PID {
     let argv: [UnsafeMutablePointer<CChar>?] = arguments.map {
         $0.withCString(strdup)
     }
 
+    
     defer {
         for case let a? in argv {
             free(a)
@@ -61,3 +63,4 @@ public func spawn(arguments: [String]) throws -> PID {
 
     return pid
 }
+#endif

--- a/Sources/POSIX/System.swift
+++ b/Sources/POSIX/System.swift
@@ -4,6 +4,8 @@
     import Darwin.C
 #endif
 
+
+#if !os(watchOS) && !os(tvOS)
 public func system(_ arguments: [String]) throws {
     fflush(stdout)
     guard !arguments.isEmpty else {
@@ -17,3 +19,4 @@ public func system(_ arguments: [String]) throws {
         throw SpawnError.exitStatus(exitStatus, arguments)
     }
 }
+#endif


### PR DESCRIPTION
Added compiler directive to leave out the spawn functions if building on watchOS or tvOS as those are not available on those platforms.
